### PR TITLE
Try catch on all getLaneSpan

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0-alpha06'
+        classpath 'com.android.tools.build:gradle:3.1.0-alpha09'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:recyclerview-v7:27.0.2'
+    compile 'com.android.support:recyclerview-v7:27.1.0'
 }

--- a/library/src/main/java/org/lucasr/twowayview/widget/ItemSpacingOffsets.java
+++ b/library/src/main/java/org/lucasr/twowayview/widget/ItemSpacingOffsets.java
@@ -48,9 +48,13 @@ class ItemSpacingOffsets {
             previousPosition--;
         }
 
-        final int previousLaneSpan = lm.getLaneSpanForPosition(previousPosition);
-        if (previousLane == 0) {
-            return (lane == previousLane + previousLaneSpan);
+        try {
+            final int previousLaneSpan = lm.getLaneSpanForPosition(previousPosition);
+            if (previousLane == 0) {
+                return (lane == previousLane + previousLaneSpan);
+            }
+        } catch (IllegalStateException e) {
+            // Lane span for position not available
         }
 
         return false;
@@ -67,9 +71,13 @@ class ItemSpacingOffsets {
 
         int count = 0;
         for (int i = 0; i < itemPosition; i++) {
-            count += lm.getLaneSpanForPosition(i);
-            if (count >= laneCount) {
-                return false;
+            try {
+                count += lm.getLaneSpanForPosition(i);
+                if (count >= laneCount) {
+                    return false;
+                }
+            } catch (IllegalStateException e) {
+                // Ignore lane span
             }
         }
 
@@ -109,7 +117,13 @@ class ItemSpacingOffsets {
 
         lm.getLaneForPosition(mTempLaneInfo, itemPosition, Direction.END);
         final int lane = mTempLaneInfo.startLane;
-        final int laneSpan = lm.getLaneSpanForPosition(itemPosition);
+        int laneSpanSecure = 0;
+        try {
+            laneSpanSecure = lm.getLaneSpanForPosition(itemPosition);
+        } catch (IllegalStateException e) {
+            // Lane span for position not available
+        }
+        final int laneSpan = laneSpanSecure;
         final int laneCount = lm.getLanes().getCount();
         final int itemCount = parent.getAdapter().getItemCount();
 


### PR DESCRIPTION
Hot fix for https://n3twork.atlassian.net/browse/NW-624.
This is just a try-catch all the things in ItemSpacingOffsets that are used in the decorator. 
This should stop the crash from happening but I'm not 100% sure what will be the outcome of it. My logic would be that there could be one missing offset between element but we should be ok. 

I plan to deep dive into this logic and try to understand all the logic behind this LayoutManager. We need to optimize it and probably create our own implementation. But for now this should be a hack to stop the app from crashing in some strange cases.